### PR TITLE
chore: refactor to require client

### DIFF
--- a/src/rush_py2/auto3d.py
+++ b/src/rush_py2/auto3d.py
@@ -5,13 +5,10 @@ from string import Template
 from gql.transport.exceptions import TransportQueryError
 
 from rush_py2.client import (
-    PROJECT_ID,
+    Client,
     RunOpts,
     RunSpec,
-    collect_run,
     print_run_trace,
-    save_object,
-    submit_rex,
 )
 from rush_py2.utils import bool_to_str, float_to_str
 
@@ -64,6 +61,8 @@ class Auto3DOptions:
 
 
 def auto3d(
+    client: Client,
+    project_id: str,
     smis: list[str],
     opts: Auto3DOptions = Auto3DOptions(),
     run_spec: RunSpec = RunSpec(),
@@ -84,11 +83,11 @@ in
         run_spec=run_spec.to_rex(),
     )
     try:
-        run_id = submit_rex(PROJECT_ID, rex, run_opts)
+        run_id = client.submit_rex(project_id, rex, run_opts)
         if not collect:
             return run_id
 
-        run = collect_run(run_id)
+        run = client.collect_run(run_id)
         if run is None:
             print("No run available", file=sys.stderr)
             return None
@@ -101,7 +100,7 @@ in
                     if "Ok" in smi_confs_res:
                         all_smi_confs.append(
                             tuple(
-                                save_object(smi_conf_vobj["path"], run_id)
+                                client.save_object(smi_conf_vobj["path"])
                                 for smi_conf_vobj in smi_confs_res["Ok"]
                             )
                         )

--- a/src/rush_py2/client.py
+++ b/src/rush_py2/client.py
@@ -9,29 +9,15 @@ from string import Template
 from typing import Literal
 
 import requests
-from gql import Client, FileVar, gql
+from gql import Client as GqlClient, FileVar, gql
 from gql.transport.requests import RequestsHTTPTransport
 
 from .utils import clean_dict, optional_str
 
-INITIAL_POLL_INTERVAL = 0.5
-MAX_POLL_INTERVAL = 30
-BACKOFF_FACTOR = 1.5
-MAX_WAIT_TIME = 3600
-
-
-GRAPHQL_ENDPOINT = getenv(
-    "RUSH_ENDPOINT",
+RUSH_URL = getenv(
+    "RUSH_URL",
     "https://tengu-server-staging-seaography-720805281970.asia-southeast1.run.app",
 )
-
-API_KEY = getenv("RUSH_TOKEN")
-if not API_KEY:
-    raise Exception("RUSH_TOKEN must be set")
-
-PROJECT_ID = getenv("RUSH_PROJECT")
-if not PROJECT_ID:
-    raise Exception("RUSH_PROJECT must be set")
 
 MODULE_OVERRIDES = getenv("RUSH_MODULE_LOCK")
 MODULE_OVERRIDES = json.loads(MODULE_OVERRIDES) if MODULE_OVERRIDES else {}
@@ -46,7 +32,7 @@ MODULE_LOCK = (
         "pbsa_rex": "github:talo/pbsa-cuda/f8b1c357fddfebf7e0c51a84f8d4e70958440c00#pbsa_rex",
         "prepare_protein_rex": "github:talo/tengu-prepare-protein/085222a5eec82dcb1dacf2b3c497e8907bd6790e#prepare_protein_rex",
     }
-    if "staging" in GRAPHQL_ENDPOINT
+    if "staging" in RUSH_URL
     else {
         # prod
         "auto3d_rex": "github:talo/tengu-auto3d/ce81cfb6f4f2628cee07400992650c15ccec790e#auto3d_rex",
@@ -57,23 +43,6 @@ MODULE_LOCK = (
         "prepare_protein_rex": "github:talo/tengu-prepare-protein/33575f99ec89bd6e28b42ac28d8e992ca137d9a7#prepare_protein_rex",
     }
 ) | MODULE_OVERRIDES
-
-_client: Client | None = None
-
-
-def _get_client() -> Client:
-    global _client
-
-    if _client is None:
-        _client = Client(
-            transport=RequestsHTTPTransport(
-                url=GRAPHQL_ENDPOINT,
-                headers={"Authorization": f"Bearer {API_KEY}"},
-            )
-        )
-
-    return _client
-
 
 type TargetT = Literal["Bullet", "Bullet2", "Bullet3", "Gadi", "Setonix"]
 
@@ -120,109 +89,253 @@ class RunSpec:
         )
 
 
-def upload_object(project_id: str, filepath: Path | str):
-    mutation = gql("""
-        mutation UploadObject($file: Upload!, $typeinfo: Json!, $format: ObjectFormatEnum!, $project_id: String) {
-            upload_object(file: $file, typeinfo: $typeinfo, format: $format, project_id: $project_id) {
-                id
-                object {
-                    path
-                    size
-                    format
+@dataclass
+class RunOpts:
+    """
+    The name of the run will show up as the name (i.e. title) of the run in the Rush UI.
+    The description currently doesn't show up anywhere.
+    The tags will also show up in the Rush UI and will (eventually) allow for run searching and filtering.
+    The email flag, if set to True, will cause an email to be sent to you upon run completion.
+    """
+
+    name: str | None = None
+    description: str | None = None
+    tags: list[str] | None = None
+    email: bool | None = None
+
+
+class Client:
+    gql_client: GqlClient
+    initial_poll_interval: float
+    max_poll_interval: float
+    backoff_factor: float
+    max_wait_time: int
+
+    def __init__(self,
+            api_url: str,
+            api_token: str,
+            initial_poll_interval: float = 0.5, 
+            max_poll_interval: float = 30, 
+            backoff_factor: float = 1.5, 
+            max_wait_time: int = 3600):
+
+        self.gql_client = GqlClient(
+            transport=RequestsHTTPTransport(
+                url=RUSH_URL,
+                headers={"Authorization": f"Bearer {api_token}"},
+            )
+        )
+        self.initial_poll_interval = initial_poll_interval
+        self.max_poll_interval = max_poll_interval
+        self.backoff_factor = backoff_factor
+        self.max_wait_time = max_wait_time
+
+    def upload_object(self, project_id: str, filepath: Path | str):
+        mutation = gql("""
+            mutation UploadObject($file: Upload!, $typeinfo: Json!, $format: ObjectFormatEnum!, $project_id: String) {
+                upload_object(file: $file, typeinfo: $typeinfo, format: $format, project_id: $project_id) {
+                    id
+                    object {
+                        path
+                        size
+                        format
+                    }
+                    base_url
+                    url
                 }
-                base_url
-                url
             }
-        }
-     """)
-    if isinstance(filepath, str):
-        filepath = Path(filepath)
-    with filepath.open(mode="rb") as f:
-        if filepath.suffix == ".json":
-            mutation.variable_values = {
-                "file": FileVar(f),
-                "format": "json",
-                "typeinfo": {
-                    "k": "record",
-                    "t": {},
-                },
-                "project_id": project_id,
-            }
-        else:
-            mutation.variable_values = {
-                "file": FileVar(f),
-                "format": "bin",
-                "typeinfo": {
-                    "k": "record",
-                    "t": {
-                        "size": "u32",
-                        "path": {
-                            "k": "@",
-                            "t": "$Bytes",
-                        },
+        """)
+        if isinstance(filepath, str):
+            filepath = Path(filepath)
+        with filepath.open(mode="rb") as f:
+            if filepath.suffix == ".json":
+                mutation.variable_values = {
+                    "file": FileVar(f),
+                    "format": "json",
+                    "typeinfo": {
+                        "k": "record",
+                        "t": {},
                     },
-                    "n": "Object",
-                },
-                "project_id": project_id,
-            }
-        result = _get_client().execute(mutation, upload_files=True)
+                    "project_id": project_id,
+                }
+            else:
+                mutation.variable_values = {
+                    "file": FileVar(f),
+                    "format": "bin",
+                    "typeinfo": {
+                        "k": "record",
+                        "t": {
+                            "size": "u32",
+                            "path": {
+                                "k": "@",
+                                "t": "$Bytes",
+                            },
+                        },
+                        "n": "Object",
+                    },
+                    "project_id": project_id,
+                }
+            result = self.gql_client.execute(mutation, upload_files=True)
 
-    obj = result["upload_object"]["object"]
-    return obj
+        obj = result["upload_object"]["object"]
+        return obj
 
 
-def download_object(path: str):
-    # TODO: enforce UUID type
-    query = gql("""
-        query GetObject($path: String!) {
-            object_path(path: $path) {
-                url
-                object {
-                    format
-                    size
+    def download_object(self, path: str):
+        # TODO: enforce UUID type
+        query = gql("""
+            query GetObject($path: String!) {
+                object_path(path: $path) {
+                    url
+                    object {
+                        format
+                        size
+                    }
                 }
             }
-        }
-    """)
-    query.variable_values = {"path": path}
+        """)
+        query.variable_values = {"path": path}
 
-    result = _get_client().execute(query)
-    obj_descriptor = result["object_path"]
+        result = self.gql_client.execute(query)
+        obj_descriptor = result["object_path"]
 
-    # Json
-    if obj_descriptor.get("contents") is not None:
-        return obj_descriptor["contents"]
-    # Bin
-    elif obj_descriptor.get("url"):
-        response = requests.get(obj_descriptor["url"])
-        response.raise_for_status()
-        return response.content
+        # Json
+        if obj_descriptor.get("contents") is not None:
+            return obj_descriptor["contents"]
+        # Bin
+        elif obj_descriptor.get("url"):
+            response = requests.get(obj_descriptor["url"])
+            response.raise_for_status()
+            return response.content
 
-    raise Exception(f"Object at path {path} has neither contents nor URL")
-
-
-def save_object(path):
-    qm_output_json = json.loads(download_object(path).decode())
-    out_path = f"{path}.json"
-    with open(out_path, "w") as f:
-        json.dump(clean_dict(qm_output_json), f, indent=2)
-    return out_path
+        raise Exception(f"Object at path {path} has neither contents nor URL")
 
 
-def fetch_results(run_id: str):
-    query = gql("""
-        query GetResults($id: String!) {
-            run(id: $id) {
-                status
-                result
-                trace
+    def save_object(self, path):
+        qm_output_json = json.loads(self.download_object(path).decode())
+        out_path = f"{path}.json"
+        with open(out_path, "w") as f:
+            json.dump(clean_dict(qm_output_json), f, indent=2)
+        return out_path
+
+
+    def fetch_results(self, run_id: str):
+        query = gql("""
+            query GetResults($id: String!) {
+                run(id: $id) {
+                    status
+                    result
+                    trace
+                }
             }
-        }
-    """)
-    query.variable_values = {"id": run_id}
+        """)
+        query.variable_values = {"id": run_id}
 
-    result = _get_client().execute(query)
-    return result["run"]
+        result = self.gql_client.execute(query)
+        return result["run"]
+
+
+    def submit_rex(self, project_id: str, rex: str, run_opts: RunOpts = RunOpts()):
+        mutation = gql("""
+            mutation EvalRex($input: CreateRun!) {
+                eval(input: $input) {
+                    id
+                    status
+                    created_at
+                }
+            }
+        """)
+        mutation.variable_values = {
+            "input": {
+                "rex": rex,
+                "module_lock": MODULE_LOCK,
+                "draft": False,
+                "project_id": project_id,
+            },
+        }
+        mutation.variable_values["input"] |= {
+            k: v for k, v in asdict(run_opts).items() if v is not None
+        }
+
+        result = self.gql_client.execute(mutation)
+        run_id = result["eval"]["id"]
+        created_at = result["eval"]["created_at"].split(".")[0]
+        print(f"Run submitted @ {created_at} with ID: {run_id}", file=sys.stderr)
+        return run_id
+
+
+    def collect_run(self, run_id: str):
+        query = gql("""
+            query GetStatus($id: String!) {
+                run(id: $id) {
+                    status
+                    module_instances {
+                        nodes {
+                            created_at
+                            admitted_at
+                            dispatched_at
+                            queued_at
+                            run_at
+                            completed_at
+                            deleted_at
+                            status
+                            failure_reason
+                            failure_context {
+                                stdout
+                                stderr
+                                syserr
+                            }
+                        }
+                    }
+                }
+            }
+        """)
+        query.variable_values = {"id": run_id}
+
+        start_time = time.time()
+        poll_interval = self.initial_poll_interval
+        last_status = None
+        while time.time() - start_time < self.max_wait_time:
+            time.sleep(poll_interval)
+
+            result = self.gql_client.execute(query)
+            status = result["run"]["status"]
+            module_instances = result["run"]["module_instances"]["nodes"]
+            if module_instances:
+                curr_status = module_instances[0]["status"]
+                if curr_status == "running":
+                    curr_status = "run"
+                if (
+                    curr_status
+                    in [
+                        "admitted",
+                        "dispatched",
+                        "queued",
+                        "run",
+                        "completed",
+                        "deleted",
+                    ]
+                    and curr_status != last_status
+                ):
+                    curr_status_time = module_instances[0][f"{curr_status}_at"].split(".")[
+                        0
+                    ]
+                    print(f"• {curr_status:11} @ {curr_status_time}", file=sys.stderr)
+                    poll_interval = self.initial_poll_interval
+                    last_status = curr_status
+                poll_interval = min(poll_interval * self.backoff_factor, self.max_poll_interval)
+            else:
+                poll_interval = min(poll_interval * self.backoff_factor, 2)
+
+            if status in ["done", "error", "cancelled"]:
+                if not last_status:
+                    print("Restored already-completed run", file=sys.stderr)
+                return self.fetch_results(run_id)
+
+            poll_interval = min(poll_interval * self.backoff_factor, self.max_poll_interval)
+
+        raise Exception(f"Run timed out: did not complete within {self.max_wait_time} seconds")
+
 
 
 def print_run_trace(result):
@@ -256,118 +369,6 @@ def print_run_trace(result):
         print(file=sys.stderr)
 
 
-@dataclass
-class RunOpts:
-    """
-    The name of the run will show up as the name (i.e. title) of the run in the Rush UI.
-    The description currently doesn't show up anywhere.
-    The tags will also show up in the Rush UI and will (eventually) allow for run searching and filtering.
-    The email flag, if set to True, will cause an email to be sent to you upon run completion.
-    """
-
-    name: str | None = None
-    description: str | None = None
-    tags: list[str] | None = None
-    email: bool | None = None
 
 
-def submit_rex(project_id: str, rex: str, run_opts: RunOpts = RunOpts()):
-    mutation = gql("""
-        mutation EvalRex($input: CreateRun!) {
-            eval(input: $input) {
-                id
-                status
-                created_at
-            }
-        }
-    """)
-    mutation.variable_values = {
-        "input": {
-            "rex": rex,
-            "module_lock": MODULE_LOCK,
-            "draft": False,
-            "project_id": project_id,
-        },
-    }
-    mutation.variable_values["input"] |= {
-        k: v for k, v in asdict(run_opts).items() if v is not None
-    }
 
-    result = _get_client().execute(mutation)
-    run_id = result["eval"]["id"]
-    created_at = result["eval"]["created_at"].split(".")[0]
-    print(f"Run submitted @ {created_at} with ID: {run_id}", file=sys.stderr)
-    return run_id
-
-
-def collect_run(run_id: str, max_wait_time: int = MAX_WAIT_TIME):
-    query = gql("""
-        query GetStatus($id: String!) {
-            run(id: $id) {
-                status
-                module_instances {
-                    nodes {
-                        created_at
-                        admitted_at
-                        dispatched_at
-                        queued_at
-                        run_at
-                        completed_at
-                        deleted_at
-                        status
-                        failure_reason
-                        failure_context {
-                            stdout
-                            stderr
-                            syserr
-                        }
-                    }
-                }
-            }
-        }
-    """)
-    query.variable_values = {"id": run_id}
-
-    start_time = time.time()
-    poll_interval = INITIAL_POLL_INTERVAL
-    last_status = None
-    while time.time() - start_time < MAX_WAIT_TIME:
-        time.sleep(poll_interval)
-
-        result = _get_client().execute(query)
-        status = result["run"]["status"]
-        module_instances = result["run"]["module_instances"]["nodes"]
-        if module_instances:
-            curr_status = module_instances[0]["status"]
-            if curr_status == "running":
-                curr_status = "run"
-            if (
-                curr_status
-                in [
-                    "admitted",
-                    "dispatched",
-                    "queued",
-                    "run",
-                    "completed",
-                    "deleted",
-                ]
-                and curr_status != last_status
-            ):
-                curr_status_time = module_instances[0][f"{curr_status}_at"].split(".")[
-                    0
-                ]
-                print(f"• {curr_status:11} @ {curr_status_time}", file=sys.stderr)
-                poll_interval = INITIAL_POLL_INTERVAL
-                last_status = curr_status
-            poll_interval = min(poll_interval * BACKOFF_FACTOR, MAX_POLL_INTERVAL)
-        else:
-            poll_interval = min(poll_interval * BACKOFF_FACTOR, 2)
-
-        if status in ["done", "error", "cancelled"]:
-            if not last_status:
-                print("Restored already-completed run", file=sys.stderr)
-            return fetch_results(run_id)
-
-        poll_interval = min(poll_interval * BACKOFF_FACTOR, MAX_POLL_INTERVAL)
-
-    raise Exception(f"Run timed out: did not complete within {MAX_WAIT_TIME} seconds")

--- a/src/rush_py2/exess.py
+++ b/src/rush_py2/exess.py
@@ -14,15 +14,10 @@ import zstandard as zstd
 from gql.transport.exceptions import TransportQueryError
 
 from .client import (
-    PROJECT_ID,
+    Client,
     RunOpts,
     RunSpec,
-    collect_run,
-    download_object,
     print_run_trace,
-    save_object,
-    submit_rex,
-    upload_object,
 )
 from .utils import bool_to_str, clean_dict, float_to_str, optional_str
 
@@ -321,11 +316,11 @@ class Restraints:
         )
 
 
-def collect_energy(run_id: str):
-    run = collect_run(run_id)
+def collect_energy(client: Client, run_id: str):
+    run = client.collect_run(run_id)
     if "Ok" in run["result"]:
         qm_output_vobj = run["result"]["Ok"][0]
-        return save_object(qm_output_vobj["path"])
+        return client.save_object(qm_output_vobj["path"])
     elif "Err" in run["result"]:
         print(f"Error: {run['result']['Err']}", file=sys.stderr)
     elif run["status"] == "error":
@@ -333,6 +328,8 @@ def collect_energy(run_id: str):
 
 
 def energy(
+    client: Client,
+    project_id: str,
     topology_path: Path | str,
     method: MethodT = "RestrictedHF",
     basis: BasisT = "cc-pVDZ",
@@ -349,7 +346,7 @@ def energy(
     """
 
     # Upload inputs
-    topology_vobj = upload_object(PROJECT_ID, topology_path)
+    topology_vobj = client.upload_object(project_id, topology_path)
 
     # Run rex
     rex = Template("""let
@@ -406,9 +403,9 @@ in
         topology_vobj_path=topology_vobj["path"],
     )
     try:
-        run_id = submit_rex(PROJECT_ID, rex, run_opts)
+        run_id = client.submit_rex(project_id, rex, run_opts)
         if collect:
-            return collect_energy(run_id)
+            return collect_energy(client, run_id)
         else:
             return run_id
 
@@ -419,6 +416,8 @@ in
 
 
 def interaction_energy(
+    client: Client,
+    project_id: str,
     topology_path: Path | str,
     reference_fragment: int,
     method: MethodT = "RestrictedHF",
@@ -437,7 +436,7 @@ def interaction_energy(
     """
 
     # Upload inputs
-    topology_vobj = upload_object(PROJECT_ID, topology_path)
+    topology_vobj = client.upload_object(project_id, topology_path)
 
     # Run rex
     rex = Template("""let
@@ -494,9 +493,9 @@ in
         topology_vobj_path=topology_vobj["path"],
     )
     try:
-        run_id = submit_rex(PROJECT_ID, rex, run_opts)
+        run_id = client.submit_rex(project_id, rex, run_opts)
         if collect:
-            return collect_energy(run_id)
+            return collect_energy(client, run_id)
         else:
             return run_id
 
@@ -507,6 +506,8 @@ in
 
 
 def chelpg(
+    client: Client,
+    project_id: str,
     topology_path: Path | str,
     system: System | None = None,
     run_spec: RunSpec = RunSpec(gpus=1),
@@ -518,7 +519,7 @@ def chelpg(
     """
 
     # Upload inputs
-    topology_vobj = upload_object(PROJECT_ID, topology_path)
+    topology_vobj = client.upload_object(project_id, topology_path)
 
     # Run rex
     rex = Template("""let
@@ -601,25 +602,25 @@ in
         topology_vobj_path=topology_vobj["path"],
     )
     try:
-        run_id = submit_rex(PROJECT_ID, rex, run_opts)
+        run_id = client.submit_rex(project_id, rex, run_opts)
         if collect:
-            run = collect_run(run_id)
+            run = client.collect_run(run_id)
             if "Ok" in run["result"]:
-                out_path = save_object(run["result"]["Ok"][0]["path"])
-                qm_output = download_object(run["result"]["Ok"][1]["path"])
+                out_path = client.save_object(run["result"]["Ok"][0]["path"])
+                qm_output = client.download_object(run["result"]["Ok"][1]["path"])
                 decompressed = zstd.ZstdDecompressor().decompress(
                     qm_output, max_output_size=int(1e8)
                 )
                 with tarfile.open(fileobj=BytesIO(decompressed)) as tar:
                     hdf5_f = tar.extractfile(tar.getnames()[1])
                     chelpg = []
-                    with h5py.File(hdf5_f, "r") as f:
-                        frag_indices = [int(x) for x in f["monomers"].keys()]
+                    with h5py.File(hdf5_f, "r") as h:
+                        frag_indices = [int(x) for x in h["monomers"].keys()]
                         for frag_idx in sorted(frag_indices):
                             # pyright: ignore[reportGeneralTypeIssues]
                             chelpg += [
                                 float(x)
-                                for x in f[f"monomers/{frag_idx}/chelpg_charges"]
+                                for x in h[f"monomers/{frag_idx}/chelpg_charges"].values()
                             ]
                 return (out_path, chelpg)
             elif "Err" in run["result"]:
@@ -636,6 +637,8 @@ in
 
 
 def qmmm(
+    client: Client,
+    project_id: str,
     topology_path: Path | str,
     residues_path: Path | str,
     n_timesteps: int,
@@ -670,8 +673,8 @@ def qmmm(
     """
 
     # Upload inputs
-    topology_vobj = upload_object(PROJECT_ID, topology_path)
-    residues_vobj = upload_object(PROJECT_ID, residues_path)
+    topology_vobj = client.upload_object(project_id, topology_path)
+    residues_vobj = client.upload_object(project_id, residues_path)
 
     # Run rex
     rex = Template("""let
@@ -755,11 +758,11 @@ in
         residues_vobj_path=residues_vobj["path"],
     )
     try:
-        run_id = submit_rex(PROJECT_ID, rex, run_opts)
+        run_id = client.submit_rex(project_id, rex, run_opts)
         if collect:
-            run = collect_run(run_id)
+            run = client.collect_run(run_id)
             if "Ok" in run["result"]:
-                return save_object(run["result"]["Ok"]["path"])
+                return client.save_object(run["result"]["Ok"]["path"])
             elif "Err" in run["result"]:
                 print(f"Error: {run['result']['Err']}", file=sys.stderr)
             elif run["status"] == "error":
@@ -961,6 +964,8 @@ class OptimizationKeywords:
 
 
 def optimization(
+    client: Client,
+    project_id: str,
     topology_path: Path | str,
     max_iters: int,
     optimization_keywords: OptimizationKeywords = OptimizationKeywords(),
@@ -987,7 +992,7 @@ def optimization(
     """
 
     # Upload inputs
-    topology_vobj = upload_object(PROJECT_ID, topology_path)
+    topology_vobj = client.upload_object(project_id, topology_path)
 
     # Run rex
     rex = Template("""let
@@ -1055,12 +1060,12 @@ in
         topology_vobj_path=topology_vobj["path"],
     )
     try:
-        run_id = submit_rex(PROJECT_ID, rex, run_opts)
+        run_id = client.submit_rex(project_id, rex, run_opts)
         if collect:
-            run = collect_run(run_id)
+            run = client.collect_run(run_id)
             if "Ok" in run["result"]:
-                out_path0 = save_object(run["result"]["Ok"][0]["path"])
-                out_path1 = save_object(run["result"]["Ok"][1]["path"])
+                out_path0 = client.save_object(run["result"]["Ok"][0]["path"])
+                out_path1 = client.save_object(run["result"]["Ok"][1]["path"])
                 return (out_path0, out_path1)
             elif "Err" in run["result"]:
                 print(f"Error: {run['result']['Err']}", file=sys.stderr)

--- a/src/rush_py2/mol.py
+++ b/src/rush_py2/mol.py
@@ -76,7 +76,7 @@ class Element(IntEnum):
 
         # Try common variations
         if symbol_upper in ["D"]:  # Deuterium -> Hydrogen
-            return cls.H
+            return Self.H
 
         raise ValueError(f"Unknown element symbol: {symbol}")
 
@@ -427,7 +427,7 @@ class Topology:
             }
 
         return [
-            i
+            AtomRef(i)
             for (i, f) in enumerate(self.fragments)
             if (i != frag_idx and not near_atoms.isdisjoint(f))
         ]

--- a/src/rush_py2/pbsa.py
+++ b/src/rush_py2/pbsa.py
@@ -8,13 +8,10 @@ import cyclopts
 from gql.transport.exceptions import TransportQueryError
 
 from .client import (
-    PROJECT_ID,
+    Client,
     RunOpts,
     RunSpec,
-    collect_run,
     print_run_trace,
-    submit_rex,
-    upload_object,
 )
 from .utils import float_to_str
 
@@ -27,6 +24,8 @@ class PBSAResults:
 
 
 def pbsa(
+    client: Client,
+    project_id: str,
     topology_path: Path | str,
     solute_dielectric: float,
     solvent_dielectric: float,
@@ -52,7 +51,7 @@ def pbsa(
     """
 
     # Upload inputs
-    topology_vobj = upload_object(PROJECT_ID, topology_path)
+    topology_vobj = client.upload_object(project_id, topology_path)
 
     # Run rex
     rex = Template("""let
@@ -93,9 +92,9 @@ in
         topology_vobj_path=topology_vobj["path"],
     )
     try:
-        run_id = submit_rex(PROJECT_ID, rex, run_opts)
+        run_id = client.submit_rex(project_id, rex, run_opts)
         if collect:
-            run = collect_run(run_id)
+            run = client.collect_run(run_id)
             if run["status"] == "done":
                 return PBSAResults(*run["result"])
             elif run["status"] == "error":

--- a/src/rush_py2/prepare_protein.py
+++ b/src/rush_py2/prepare_protein.py
@@ -10,19 +10,17 @@ import cyclopts
 from gql.transport.exceptions import TransportQueryError
 
 from .client import (
-    PROJECT_ID,
+    Client,
     RunOpts,
     RunSpec,
-    collect_run,
-    download_object,
     print_run_trace,
-    submit_rex,
-    upload_object,
 )
 from .utils import clean_dict, float_to_str
 
 
 def prepare_protein(
+    client: Client,
+    project_id: str,
     trc_path: Path | str,
     ph: float | None = None,
     naming_scheme: Literal["AMBER", "CHARMM"] | None = None,
@@ -52,9 +50,9 @@ def prepare_protein(
         t_f.seek(0)
         r_f.seek(0)
         c_f.seek(0)
-        topology_vobj = upload_object(PROJECT_ID, t_f.name)
-        residues_vobj = upload_object(PROJECT_ID, r_f.name)
-        chains_vobj = upload_object(PROJECT_ID, c_f.name)
+        topology_vobj = client.upload_object(project_id, t_f.name)
+        residues_vobj = client.upload_object(project_id, r_f.name)
+        chains_vobj = client.upload_object(project_id, c_f.name)
 
     # Run rex
     rex = Template("""let
@@ -83,14 +81,14 @@ in
         chains_vobj_path=chains_vobj["path"],
     )
     try:
-        run_id = submit_rex(PROJECT_ID, rex, run_opts)
+        run_id = client.submit_rex(project_id, rex, run_opts)
         if collect:
-            run = collect_run(run_id)
+            run = client.collect_run(run_id)
             if "Ok" in run["result"]:
                 trc_o_tuple = run["result"]["Ok"][0]
-                t_o_dict = json.loads(download_object(trc_o_tuple[0]["path"]).decode())
-                r_o_dict = json.loads(download_object(trc_o_tuple[1]["path"]).decode())
-                c_o_dict = json.loads(download_object(trc_o_tuple[2]["path"]).decode())
+                t_o_dict = json.loads(client.download_object(trc_o_tuple[0]["path"]).decode())
+                r_o_dict = json.loads(client.download_object(trc_o_tuple[1]["path"]).decode())
+                c_o_dict = json.loads(client.download_object(trc_o_tuple[2]["path"]).decode())
                 trc_o_dict = {
                     "topology": t_o_dict,
                     "residues": r_o_dict,

--- a/tests/test_auto3d.py
+++ b/tests/test_auto3d.py
@@ -1,12 +1,30 @@
-from pathlib import Path
+from os import getenv
 from pprint import pp
 
 from rush_py2 import from_json
 from rush_py2.auto3d import Auto3DOptions, auto3d
+from rush_py2.client import Client
+
+
+API_TOKEN = getenv("RUSH_API_TOKEN")
+if not API_TOKEN:
+    raise Exception("RUSH_API_TOKEN must be set")
+
+PROJECT_ID = getenv("RUSH_PROJECT_ID")
+if not PROJECT_ID:
+    raise Exception("RUSH_PROJECT_ID must be set")
 
 if __name__ == "__main__":
-    result1, result2 = auto3d(
-        ["CC(C)Cc1ccc(cc1)[C@@H](C)C(=O)O", "COOH"], Auto3DOptions(k=5), collect=True
+
+    client = Client(api_url="https://tengu-server-staging-seaography-720805281970.asia-southeast1.run.app", api_token=API_TOKEN)
+    result = auto3d(
+        client,
+        PROJECT_ID,
+        ["CC(C)Cc1ccc(cc1)[C@@H](C)C(=O)O", "COOH"], 
+        Auto3DOptions(k=5), 
+        collect=True
     )
-    pp(from_json(result1), width=130, compact=True)
-    print(result2)
+    if result is None:
+        raise Exception("No result")
+    pp(from_json(result[0]), width=130, compact=True)
+    print(result[1])

--- a/tests/test_prepare_protein.py
+++ b/tests/test_prepare_protein.py
@@ -1,10 +1,24 @@
+from os import getenv
 import sys
 
-from rush_py2.client import RunOpts, RunSpec
+from rush_py2.client import Client, RunOpts, RunSpec
 from rush_py2.prepare_protein import prepare_protein
 
+
+API_TOKEN = getenv("RUSH_API_TOKEN")
+if not API_TOKEN:
+    raise Exception("RUSH_API_TOKEN must be set")
+
+PROJECT_ID = getenv("RUSH_PROJECT_ID")
+if not PROJECT_ID:
+    raise Exception("RUSH_PROJECT_ID must be set")
+
+
 if __name__ == "__main__":
+    client = Client(api_url="https://tengu-server-staging-seaography-720805281970.asia-southeast1.run.app", api_token=API_TOKEN)
     o = prepare_protein(
+        client,
+        PROJECT_ID,
         "cdk2_dry_trc.json",
         run_spec=RunSpec(target="Bullet2"),
         run_opts=RunOpts(


### PR DESCRIPTION
Remove global client and require instantiation. Better practice (supports multiple projects, multiple environments, later we can support multiple lockfiles). 

Also fixed some Python typing errors. Unsure about the addition of `.values()` in handling HDF5 data in the EXESS code.