### PR TITLE
Update exess modules, CI improvements, and PyPI publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,41 @@
+name: Publish to PyPI
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    environment: pypi
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Setup uv
+        uses: astral-sh/setup-uv@v5
+
+      - name: Verify tag matches package version
+        run: |
+          TAG="${GITHUB_REF#refs/tags/v}"
+          VERSION=$(uv run python -c "import tomllib; print(tomllib.load(open('pyproject.toml','rb'))['project']['version'])")
+          if [ "$TAG" != "$VERSION" ]; then
+            echo "::error::Tag v$TAG does not match pyproject.toml version $VERSION"
+            exit 1
+          fi
+
+      - name: Build package
+        run: uv build
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/src/rush/client.py
+++ b/src/rush/client.py
@@ -44,7 +44,11 @@ def _load_dotenv() -> dict[str, str]:
                     key, _, value = line.partition("=")
                     key = key.strip()
                     value = value.strip()
-                    if len(value) >= 2 and value[0] in ('"', "'") and value[-1] == value[0]:
+                    if (
+                        len(value) >= 2
+                        and value[0] in ('"', "'")
+                        and value[-1] == value[0]
+                    ):
                         value = value[1:-1]
                     _dotenv_cache.setdefault(key, value)
             break
@@ -86,9 +90,9 @@ MODULE_LOCK = (
         # staging
         "auto3d_rex": "github:talo/tengu-auto3d/ce81cfb6f4f2628cee07400992650c15ccec790e#auto3d_rex",
         "boltz2_rex": "github:talo/tengu-boltz2/76df0b4b4fa42e88928a430a54a28620feef8ea8#boltz2_rex",
-        "exess_rex": "github:talo/tengu-exess/43203d3b9fc36c692ee405c37d548bc9e949e0af#exess_rex",
+        "exess_rex": "github:talo/tengu-exess/cdbe814fbc6841cddacbc8fece477b978f6e1f6d#exess_rex",
         "exess_geo_opt_rex": "github:talo/tengu-exess/f64f752732d89c47731085f1a688bfd2dee6dfc7#exess_geo_opt_rex",
-        "exess_qmmm_rex": "github:talo/tengu-exess/af035b062ed491c09dba9c558a8418f3482fc924#exess_qmmm_rex",
+        "exess_qmmm_rex": "github:talo/tengu-exess/61b1874f8df65a083e9170082250473fd8e46978#exess_qmmm_rex",
         "mmseqs2_rex": "github:talo/tengu-colabfold/749a096d082efdac3ac13de4aaa98aee3347d79d#mmseqs2_rex",
         "nnxtb_rex": "github:talo/tengu-nnxtb/4e733660264d38faab5d23eadc41ca86fd6ff97a#nnxtb_rex",
         "pbsa_rex": "github:talo/pbsa-cuda/f8b1c357fddfebf7e0c51a84f8d4e70958440c00#pbsa_rex",
@@ -99,7 +103,7 @@ MODULE_LOCK = (
         # prod
         "auto3d_rex": "github:talo/tengu-auto3d/ce81cfb6f4f2628cee07400992650c15ccec790e#auto3d_rex",
         "boltz2_rex": "github:talo/tengu-boltz2/76df0b4b4fa42e88928a430a54a28620feef8ea8#boltz2_rex",
-        "exess_rex": "github:talo/tengu-exess/43203d3b9fc36c692ee405c37d548bc9e949e0af#exess_rex",
+        "exess_rex": "github:talo/tengu-exess/22220b904cdba7bcfca54e66abaee318e0a14362#exess_rex",
         "exess_geo_opt_rex": "github:talo/tengu-exess/d3d5a3dcf47b41ce3ed04fc7517bda8e375e5383#exess_geo_opt_rex",
         "exess_qmmm_rex": "github:talo/tengu-exess/61b1874f8df65a083e9170082250473fd8e46978#exess_qmmm_rex",
         "mmseqs2_rex": "github:talo/tengu-colabfold/0b6ca8b9dc97fc6380d334169a6faae51d85fac7#mmseqs2_rex",
@@ -837,7 +841,9 @@ def collect_run(run_id: str, max_wait_time: int = 3600) -> dict | RunError:
         elif "Err" in result:
             print(f"Error: {result['Err']}", file=sys.stderr)
             _print_run_trace(run)
-            return RunError(result["Err"], )
+            return RunError(
+                result["Err"],
+            )
 
     if len(result) == 1:
         return result[0]


### PR DESCRIPTION
## Summary
- Update exess-rex module paths to latest versions (staging + prod) from `latest_modules` API
- Add CI test timeouts with queue-aware slow test skipping — slow tests auto-skip when Rush queues are busy (>2 queued/admitted jobs)
- Add PyPI publish workflow using OIDC trusted publishing, triggered on `v*` tags with version verification
- Add Claude Code project setup (CLAUDE.md, hooks, type-checker agent)

## Test plan
- [x] `uv run pytest -m "not slow" -v` runs only fast tests
- [x] `uv run pytest -v` auto-skips slow tests when queues busy
- [ ] Verify publish workflow triggers correctly on tag push
- [ ] Confirm exess tests pass with updated module paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)