### PR TITLE
Release v6.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,13 @@
+# Changelog
+
+## 6.5.0
+
+### Changed
+- Updated EXESS module paths to latest versions (staging: `exess_rex`, `exess_qmmm_rex`; prod: `exess_rex`)
+
+### Added
+- PyPI publish workflow using OIDC trusted publishing, triggered on `v*` tags
+- CI test timeouts with queue-aware slow test skipping — slow tests auto-skip when Rush queues are busy
+- `pytest-timeout` dependency with per-test timeouts (300s default, 600s for slow tests)
+- `--run-slow-force` pytest option to bypass queue check
+- `run_tests.sh` argument handling (`--quick`, `--slow`, `--all`)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "rush-py"
-version = "6.4.0"
+version = "6.5.0"
 description = "Python client for QDX's Rush platform"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/rush/client.py
+++ b/src/rush/client.py
@@ -90,7 +90,7 @@ MODULE_LOCK = (
         # staging
         "auto3d_rex": "github:talo/tengu-auto3d/ce81cfb6f4f2628cee07400992650c15ccec790e#auto3d_rex",
         "boltz2_rex": "github:talo/tengu-boltz2/76df0b4b4fa42e88928a430a54a28620feef8ea8#boltz2_rex",
-        "exess_rex": "github:talo/tengu-exess/cdbe814fbc6841cddacbc8fece477b978f6e1f6d#exess_rex",
+        "exess_rex": "github:talo/tengu-exess/ac24fadc935aa66b398aad3bacffc30f6cf3116a#exess_rex",
         "exess_geo_opt_rex": "github:talo/tengu-exess/f64f752732d89c47731085f1a688bfd2dee6dfc7#exess_geo_opt_rex",
         "exess_qmmm_rex": "github:talo/tengu-exess/61b1874f8df65a083e9170082250473fd8e46978#exess_qmmm_rex",
         "mmseqs2_rex": "github:talo/tengu-colabfold/749a096d082efdac3ac13de4aaa98aee3347d79d#mmseqs2_rex",
@@ -103,7 +103,7 @@ MODULE_LOCK = (
         # prod
         "auto3d_rex": "github:talo/tengu-auto3d/ce81cfb6f4f2628cee07400992650c15ccec790e#auto3d_rex",
         "boltz2_rex": "github:talo/tengu-boltz2/76df0b4b4fa42e88928a430a54a28620feef8ea8#boltz2_rex",
-        "exess_rex": "github:talo/tengu-exess/22220b904cdba7bcfca54e66abaee318e0a14362#exess_rex",
+        "exess_rex": "github:talo/tengu-exess/ac24fadc935aa66b398aad3bacffc30f6cf3116a#exess_rex",
         "exess_geo_opt_rex": "github:talo/tengu-exess/d3d5a3dcf47b41ce3ed04fc7517bda8e375e5383#exess_geo_opt_rex",
         "exess_qmmm_rex": "github:talo/tengu-exess/61b1874f8df65a083e9170082250473fd8e46978#exess_qmmm_rex",
         "mmseqs2_rex": "github:talo/tengu-colabfold/0b6ca8b9dc97fc6380d334169a6faae51d85fac7#mmseqs2_rex",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -83,7 +83,8 @@ def pytest_collection_modifyitems(
     for item in items:
         if not _is_fast_test(item):
             item.add_marker(slow_marker)
-            item.add_marker(slow_timeout)
+            if not any(m.name == "timeout" for m in item.iter_markers()):
+                item.add_marker(slow_timeout)
 
 
 def pytest_runtest_setup(item: pytest.Item) -> None:

--- a/tests/test_exess_interaction_energy.py
+++ b/tests/test_exess_interaction_energy.py
@@ -24,7 +24,7 @@ def test_exess_interaction_energy():
         ),
         run_opts=RunOpts(
             name="Rush-Py Test EXESS Energy 02: Interaction Energy w/ Frag Keywords",
-            tags=["rush-py", "test", "tyk2+ejm-31"],
+            tags=["rush-py", "test", "tyk2+ejm-31", "deploy"],
         ),
         collect=True,
     )

--- a/tests/test_exess_interaction_energy_gadi.py
+++ b/tests/test_exess_interaction_energy_gadi.py
@@ -1,0 +1,40 @@
+import sys
+from pathlib import Path
+
+import pytest
+
+from rush import Topology, exess
+from rush.client import RunOpts, RunSpec, set_opts
+
+
+@pytest.mark.timeout(1800)
+def test_exess_interaction_energy_gadi():
+    set_opts(workspace_dir=Path.cwd() / "test-runs")
+    data_dir = Path.cwd() / "tests" / "data"
+    topology = Topology.from_json(data_dir / "tyk2_ejm_31_t.json")
+    lig_idx = 93
+    frag_idcs = topology.get_fragments_near_fragment(lig_idx, 6.0) + [lig_idx]
+    res = exess.interaction_energy(
+        data_dir / "tyk2_ejm_31_t.json",
+        lig_idx,
+        frag_keywords=exess.FragKeywords(
+            level="Trimer",
+            dimer_cutoff=5.0,
+            trimer_cutoff=1.0,
+            cutoff_type="Centroid",
+            distance_metric="Min",
+            included_fragments=frag_idcs,
+        ),
+        run_opts=RunOpts(
+            name="Rush-Py Test EXESS Interaction Energy: Gadi",
+            tags=["rush-py", "test", "tyk2+ejm-31", "gadi"],
+        ),
+        run_spec=RunSpec(target="Gadi"),
+        collect=True,
+    )
+    print(res, file=sys.stderr)
+    exess.save_energy_outputs(res)
+
+
+if __name__ == "__main__":
+    test_exess_interaction_energy_gadi()

--- a/tests/test_exess_interaction_energy_setonix.py
+++ b/tests/test_exess_interaction_energy_setonix.py
@@ -1,0 +1,40 @@
+import sys
+from pathlib import Path
+
+import pytest
+
+from rush import Topology, exess
+from rush.client import RunOpts, RunSpec, set_opts
+
+
+@pytest.mark.timeout(1800)
+def test_exess_interaction_energy_setonix():
+    set_opts(workspace_dir=Path.cwd() / "test-runs")
+    data_dir = Path.cwd() / "tests" / "data"
+    topology = Topology.from_json(data_dir / "tyk2_ejm_31_t.json")
+    lig_idx = 93
+    frag_idcs = topology.get_fragments_near_fragment(lig_idx, 6.0) + [lig_idx]
+    res = exess.interaction_energy(
+        data_dir / "tyk2_ejm_31_t.json",
+        lig_idx,
+        frag_keywords=exess.FragKeywords(
+            level="Trimer",
+            dimer_cutoff=5.0,
+            trimer_cutoff=1.0,
+            cutoff_type="Centroid",
+            distance_metric="Min",
+            included_fragments=frag_idcs,
+        ),
+        run_opts=RunOpts(
+            name="Rush-Py Test EXESS Interaction Energy: Setonix",
+            tags=["rush-py", "test", "tyk2+ejm-31", "setonix"],
+        ),
+        run_spec=RunSpec(target="Setonix"),
+        collect=True,
+    )
+    print(res, file=sys.stderr)
+    exess.save_energy_outputs(res)
+
+
+if __name__ == "__main__":
+    test_exess_interaction_energy_setonix()


### PR DESCRIPTION
## Summary
- Bump version to 6.5.0
- Add CHANGELOG.md

### What's in 6.5.0
- Updated EXESS module paths to latest versions from `latest_modules` API
- PyPI publish workflow using OIDC trusted publishing (triggers on `v*` tags)
- CI test timeouts with queue-aware slow test skipping
- `pytest-timeout` with per-test timeouts (300s default, 600s slow)
- `run_tests.sh` argument handling (`--quick`/`--slow`/`--all`)

## Test plan
- [ ] CI passes
- [ ] After merge, tag with `git tag v6.5.0 && git push origin v6.5.0` to trigger PyPI publish

🤖 Generated with [Claude Code](https://claude.com/claude-code)