### PR TITLE
feat: add changelog CI check and walk-up .env discovery

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,49 @@
+name: Build and Deploy Docs
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'docs/**'
+
+jobs:
+  docs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+
+      - name: Build docs
+        run: uv run sphinx-build -b html docs/ docs/_build/html
+
+      - name: Deploy to gh-pages
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./_build/html
+
+      - name: Push docs to exess-webapp
+        uses: cpina/github-action-push-to-another-repository@main
+        env:
+          API_TOKEN_GITHUB: ${{ secrets.DOCS_DEPLOY_PAT }}
+        with:
+          source-directory: _build/html
+          destination-github-username: talo
+          destination-repository-name: exess-webapp
+          destination-directory: public/docs
+          target-branch: docs-update
+          create-target-branch-if-needed: true
+
+      - name: Create PR in exess-webapp
+        env:
+          GH_TOKEN: ${{ secrets.DOCS_DEPLOY_PAT }}
+        run: |
+          gh pr create \
+            --repo talo/exess-webapp \
+            --head docs-update \
+            --base main \
+            --title "Update docs from rush-py" \
+            --body "Automated docs update from rush-py commit ${{ github.sha }}" \
+            || echo "PR already exists, skipping"

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -4,46 +4,71 @@ on:
   push:
     branches: [main]
     paths:
+      - 'src/rush/**'
       - 'docs/**'
+
+permissions:
+  contents: write
 
 jobs:
   docs:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout
+        uses: actions/checkout@v6
 
-      - name: Install uv
-        uses: astral-sh/setup-uv@v5
+      - name: Setup Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - name: Setup uv
+        uses: astral-sh/setup-uv@v7
+
+      - name: Install dependencies
+        run: uv sync --dev
 
       - name: Build docs
         run: uv run sphinx-build -b html docs/ docs/_build/html
 
       - name: Deploy to gh-pages
-        uses: peaceiris/actions-gh-pages@v3
+        uses: peaceiris/actions-gh-pages@v4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./_build/html
+          publish_dir: docs/_build/html
 
       - name: Push docs to exess-webapp
-        uses: cpina/github-action-push-to-another-repository@main
+        uses: cpina/github-action-push-to-another-repository@v1
         env:
           API_TOKEN_GITHUB: ${{ secrets.DOCS_DEPLOY_PAT }}
         with:
-          source-directory: _build/html
+          source-directory: docs/_build/html
           destination-github-username: talo
           destination-repository-name: exess-webapp
           destination-directory: public/docs
           target-branch: docs-update
           create-target-branch-if-needed: true
 
-      - name: Create PR in exess-webapp
+      - name: Create or update PR in exess-webapp
         env:
           GH_TOKEN: ${{ secrets.DOCS_DEPLOY_PAT }}
         run: |
-          gh pr create \
+          existing=$(gh pr list \
             --repo talo/exess-webapp \
             --head docs-update \
             --base main \
-            --title "Update docs from rush-py" \
-            --body "Automated docs update from rush-py commit ${{ github.sha }}" \
-            || echo "PR already exists, skipping"
+            --state open \
+            --json number \
+            --jq '.[0].number // empty')
+          if [ -n "$existing" ]; then
+            gh pr comment "$existing" \
+              --repo talo/exess-webapp \
+              --body "Updated docs from rush-py commit ${{ github.sha }}"
+          else
+            gh pr create \
+              --repo talo/exess-webapp \
+              --head docs-update \
+              --base main \
+              --title "Update docs from rush-py" \
+              --body "Automated docs update from rush-py commit ${{ github.sha }}"
+          fi

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -31,3 +31,12 @@ jobs:
 
       - name: Run ty
         run: uv run ty check --output-format=github ./src ./tests
+
+      - name: Check CHANGELOG.md updated
+        if: github.event_name == 'pull_request'
+        run: |
+          git fetch origin ${{ github.base_ref }} --depth=1
+          if ! git diff --name-only origin/${{ github.base_ref }}...HEAD | grep -q '^CHANGELOG.md$'; then
+            echo "::error::CHANGELOG.md was not updated. Please add an entry describing your changes."
+            exit 1
+          fi

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,6 +14,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
 
       - name: Setup Python
         uses: actions/setup-python@v6
@@ -35,7 +37,6 @@ jobs:
       - name: Check CHANGELOG.md updated
         if: github.event_name == 'pull_request'
         run: |
-          git fetch origin ${{ github.base_ref }} --depth=1
           if ! git diff --name-only origin/${{ github.base_ref }}...HEAD | grep -q '^CHANGELOG.md$'; then
             echo "::error::CHANGELOG.md was not updated. Please add an entry describing your changes."
             exit 1

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2,13 +2,14 @@ name: Lint (ruff & ty)
 
 on:
   push:
+    branches: [main]
   pull_request:
 
 permissions:
   contents: read
 
 jobs:
-  test:
+  lint:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -2,6 +2,7 @@ name: Pytest
 
 on:
   push:
+    branches: [main]
   pull_request:
 
 permissions:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## Unreleased
+
+### Changed
+- `.env` file detection now walks up parent directories from `cwd`, so examples subfolders find the repo-root `.env` automatically
+
+### Added
+- CI changelog check in lint workflow — PRs must update `CHANGELOG.md`
+
 ## 6.6.0
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 ### Added
 - CI changelog check in lint workflow — PRs must update `CHANGELOG.md`
+- workflow to auto deploy docs to gh-pages and exess webapp when merged to main
 
 ## 6.6.0
 

--- a/src/rush/client.py
+++ b/src/rush/client.py
@@ -36,7 +36,15 @@ def _load_dotenv() -> dict[str, str]:
         return _dotenv_cache
 
     _dotenv_cache = {}
-    for path in [Path.cwd() / ".env", Path.home() / ".rush" / ".env"]:
+
+    # Walk up from cwd to find the nearest .env, then fall back to ~/.rush/.env
+    candidates: list[Path] = []
+    cwd = Path.cwd().resolve()
+    for parent in [cwd, *cwd.parents]:
+        candidates.append(parent / ".env")
+    candidates.append(Path.home() / ".rush" / ".env")
+
+    for path in candidates:
         if path.is_file():
             with open(path) as f:
                 for line in f:


### PR DESCRIPTION
Add a lint workflow step that requires CHANGELOG.md to be updated in PRs. Fix .env detection to walk up parent directories from cwd so example scripts in subfolders find the repo-root .env automatically.