### PR TITLE
feat: auto3d multiple conformers with structured output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,18 @@
 # Changelog
 
-## 6.7.3
+## 6.8.0
+
+### Changed
+- Bump `auto3d_rex` module revision (staging and prod)
+
+### Added
+- `Auto3DResult` and `Auto3DStats` dataclasses for structured conformer output
+- `save_outputs()` in `auto3d` module with bespoke dataclasses for the result TRCs and stats; TRCs downloaded and constructed fully in-memory
+
 ### Fixed
-- Center 2D charge map molecule in CHELPG HTML visualization
+- Disambiguate `prepare_protein` error message in `save_outputs()` fallback
+
+## 6.7.3
 
 ### Changed
 - Update docs style to match QDX website: dark mode, logo linking to qdx.co, nav links to EXESS and Rush
@@ -14,11 +24,16 @@
 - Expand EXESS limitations documentation (relativistic, heavy elements, excited-state methods)
 - Remove x2c-SVPall from basis set table (relativistic not currently supported)
 
+### Fixed
+- Center 2D charge map molecule in CHELPG HTML visualization
+
 ## 6.7.2
+
 ### Changed
 - Docs deploy now targets qdx-main-landing repo instead of exess-webapp
 
 ## 6.7.1
+
 ### Fixed
 - fix github action for docs publishing
 
@@ -26,11 +41,6 @@
 
 ### Changed
 - `.env` file detection now walks up parent directories from `cwd`, so examples subfolders find the repo-root `.env` automatically
-
-### Fixed
-- CHELPG tutorial code and output visualisation cleanup
-- Bar chart and 3D structure colors now match 2D visualization in CHELPG output
-- Changelog CI check was only checking the latest commit
 
 ### Added
 - Add tags to rex runs with runtime and SDK metadata
@@ -40,23 +50,26 @@
 - Charge-colored 2D aspirin structure to CHELPG output
 - Docs: basis set warnings with example code links across tutorials
 
+### Fixed
+- CHELPG tutorial code and output visualisation cleanup
+- Bar chart and 3D structure colors now match 2D visualization in CHELPG output
+- Changelog CI check was only checking the latest commit
+
 ## 6.6.0
 
 ### Changed
 - `from_json()` now always returns a list in the case of a single path input, which is more consistent
   especially given the typing challenges with determining single-vs-many output types for file inputs
 
-### Fixed
-- work around json import error due to shadowing
-- gradually type, and fix incomplete or erroneous typing, in numerous places
-
 ### Added
 - test for getting CHELPG charges from exess.energy (exess.chelpg to be removed soon)
 - add all deps needed for examples to pyproject.toml dev deps
 
-## 6.5.1
+### Fixed
+- work around json import error due to shadowing
+- gradually type, and fix incomplete or erroneous typing, in numerous places
 
-### Changed
+## 6.5.1
 
 ### Fixed
 - `save_energy_outputs()` now handles list inputs from `collect_run()`
@@ -70,8 +83,6 @@
 - Fixed `save_outputs()` to properly handle list/tuple results from `collect_run()`
 - Fixed `prepare_complex()` to respect the `collect` parameter when calling `run_prepare_protein()`
 - Updated CHELPG example script to use `save_energy_outputs()` for proper HDF5 extraction
-
-### Added
 
 ## 6.5.0
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "rush-py"
-version = "6.7.1"
+version = "6.8.0"
 description = "Python client for QDX's Rush platform"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/rush/auto3d.py
+++ b/src/rush/auto3d.py
@@ -2,7 +2,7 @@ import json
 import sys
 from dataclasses import dataclass
 from string import Template
-from typing import Generator
+from typing import Iterator
 
 from gql.transport.exceptions import TransportQueryError
 
@@ -121,13 +121,13 @@ in
                 print(f"  {error['message']}", file=sys.stderr)
 
 
-def save_outputs(res) -> list[Generator[Auto3DResult] | RunError] | str | RunError:
+def save_outputs(res) -> list[Iterator[Auto3DResult] | RunError] | str | RunError:
     """
     Download output files from an auto3d run.
 
     The auto3d rex computation returns a Rush object store pointers for TRCs
     and stats for each conformer generated. There are up to k conformers
-    per input. Each input can either succeed, in which case a Generator[Auto3DResult]
+    per input. Each input can either succeed, in which case a Iterator[Auto3DResult]
     is returned that downloads and packages each conformer on the fly, or fail,
     in which case the run error is returned.
 
@@ -144,7 +144,7 @@ def save_outputs(res) -> list[Generator[Auto3DResult] | RunError] | str | RunErr
     Returns:
         Either:
         - A run ID string (if input was a run ID)
-        - list[Generator[Auto3dResult] | RunError], if the run succeeded
+        - list[Iterator[Auto3DResult] | RunError], if the run succeeded
         - RunError if input is an error
     """
 
@@ -159,7 +159,7 @@ def save_outputs(res) -> list[Generator[Auto3DResult] | RunError] | str | RunErr
     # Handle run output
     if isinstance(res, list):
 
-        def to_auto3dresult(res_i) -> Generator[Auto3DResult]:
+        def to_auto3dresult(res_i) -> Iterator[Auto3DResult]:
             for trc_obj, stats in res_i:
                 trc_dict = {
                     "topology": json.loads(download_object(trc_obj[0]["path"])),

--- a/src/rush/auto3d.py
+++ b/src/rush/auto3d.py
@@ -1,8 +1,12 @@
+import json
 import sys
+from dataclasses import dataclass
 from string import Template
+from typing import Generator
 
 from gql.transport.exceptions import TransportQueryError
 
+from rush import TRC, from_json
 from rush.client import (
     RunError,
     RunOpts,
@@ -10,8 +14,23 @@ from rush.client import (
     _get_project_id,
     _submit_rex,
     collect_run,
+    download_object,
 )
 from rush.utils import bool_to_str, float_to_str
+
+
+@dataclass
+class Auto3DStats:
+    f_max: float
+    converged: bool
+    e_rel_kcal_mol: float
+    e_tot_hartrees: float
+
+
+@dataclass
+class Auto3DResult:
+    conformer: TRC
+    stats: Auto3DStats
 
 
 def auto3d(
@@ -100,3 +119,69 @@ in
             print("Error:", file=sys.stderr)
             for error in e.errors:
                 print(f"  {error['message']}", file=sys.stderr)
+
+
+def save_outputs(res) -> list[Generator[Auto3DResult] | RunError] | str | RunError:
+    """
+    Download output files from an auto3d run.
+
+    The auto3d rex computation returns a Rush object store pointers for TRCs
+    and stats for each conformer generated. There are up to k conformers
+    per input. Each input can either succeed, in which case a Generator[Auto3DResult]
+    is returned that downloads and packages each conformer on the fly, or fail,
+    in which case the run error is returned.
+
+    If collect=False was used, the input will be a run ID string, which is
+    returned as-is for later collection by the caller.
+
+    Args:
+        res: Either:
+             - A run ID string (if collect=False was used)
+             - The successful output from auto3d()
+             - A RunError
+             Each VirtualObject dict has keys: 'path', 'size', 'format'.
+
+    Returns:
+        Either:
+        - A run ID string (if input was a run ID)
+        - list[Generator[Auto3dResult] | RunError], if the run succeeded
+        - RunError if input is an error
+    """
+
+    # Handle error case
+    if isinstance(res, RunError):
+        return res
+
+    # Handle run ID string (collect=False case)
+    if isinstance(res, str):
+        return res
+
+    # Handle run output
+    if isinstance(res, list):
+
+        def to_auto3dresult(res_i) -> Generator[Auto3DResult]:
+            for trc_obj, stats in res_i:
+                trc_dict = {
+                    "topology": json.loads(download_object(trc_obj[0]["path"])),
+                    "residues": json.loads(download_object(trc_obj[1]["path"])),
+                    "chains": json.loads(download_object(trc_obj[2]["path"])),
+                }
+                yield Auto3DResult(
+                    from_json(trc_dict),
+                    Auto3DStats(
+                        stats["f_max"],
+                        stats["converged"],
+                        stats["e_rel_kcal_mol"],
+                        stats["e_tot_hartrees"],
+                    ),
+                )
+
+        return [
+            RunError(res_i) if isinstance(res_i, str) else to_auto3dresult(res_i)
+            for res_i in res
+        ]
+
+    # Fallback: return as-is (for debugging or unexpected formats)
+    return RunError(
+        f"Error: prepare_protein save_outputs received unexpected format: {type(res)}"
+    )

--- a/src/rush/client.py
+++ b/src/rush/client.py
@@ -100,7 +100,7 @@ MODULE_OVERRIDES = json.loads(MODULE_OVERRIDES) if MODULE_OVERRIDES else {}
 MODULE_LOCK = (
     {
         # staging
-        "auto3d_rex": "github:talo/tengu-auto3d/ce81cfb6f4f2628cee07400992650c15ccec790e#auto3d_rex",
+        "auto3d_rex": "github:talo/tengu-auto3d/88c2fdc505f206463a9c60519273563b1dddabc9#auto3d_rex",
         "boltz2_rex": "github:talo/tengu-boltz2/76df0b4b4fa42e88928a430a54a28620feef8ea8#boltz2_rex",
         "exess_rex": "github:talo/tengu-exess/ac24fadc935aa66b398aad3bacffc30f6cf3116a#exess_rex",
         "exess_geo_opt_rex": "github:talo/tengu-exess/f64f752732d89c47731085f1a688bfd2dee6dfc7#exess_geo_opt_rex",
@@ -113,7 +113,7 @@ MODULE_LOCK = (
     if "staging" in GRAPHQL_ENDPOINT
     else {
         # prod
-        "auto3d_rex": "github:talo/tengu-auto3d/ce81cfb6f4f2628cee07400992650c15ccec790e#auto3d_rex",
+        "auto3d_rex": "github:talo/tengu-auto3d/88c2fdc505f206463a9c60519273563b1dddabc9#auto3d_rex",
         "boltz2_rex": "github:talo/tengu-boltz2/76df0b4b4fa42e88928a430a54a28620feef8ea8#boltz2_rex",
         "exess_rex": "github:talo/tengu-exess/ac24fadc935aa66b398aad3bacffc30f6cf3116a#exess_rex",
         "exess_geo_opt_rex": "github:talo/tengu-exess/d3d5a3dcf47b41ce3ed04fc7517bda8e375e5383#exess_geo_opt_rex",

--- a/src/rush/prepare_protein.py
+++ b/src/rush/prepare_protein.py
@@ -164,5 +164,6 @@ def save_outputs(
         )
 
     # Fallback: return as-is (for debugging or unexpected formats)
-    print(res, file=sys.stderr)
-    return RunError(f"Error: save_outputs received unexpected format: {type(res)}")
+    return RunError(
+        f"Error: prepare_protein save_outputs received unexpected format: {type(res)}"
+    )

--- a/tests/test_auto3d.py
+++ b/tests/test_auto3d.py
@@ -1,10 +1,10 @@
+import itertools
 import sys
 from pathlib import Path
-from pprint import pp
 
-from rush import from_json
 from rush.auto3d import auto3d as run_auto3d
-from rush.client import RunOpts, save_object, set_opts
+from rush.auto3d import save_outputs
+from rush.client import RunError, RunOpts, set_opts
 
 
 def test_auto3d():
@@ -19,10 +19,27 @@ def test_auto3d():
         collect=True,
     )
     # Output is a list of TRC objects in memory, or a str if auto3d failed
-    trc_obj, err = res
-    trc = from_json(tuple(save_object(o["path"]) for o in trc_obj))
-    pp(trc, width=130, compact=True, stream=sys.stderr)
-    print(err, file=sys.stderr)
+    res = save_outputs(res)
+    assert not isinstance(res, (str, RunError))
+    assert len(res) == 2
+
+    # res[0] expected to succeed
+    assert not isinstance(res[0], RunError)
+    for i, x in enumerate(res[0]):
+        print(f"Conformer {i}:")
+        for atom, coords in zip(
+            x.conformer.topology.symbols,
+            itertools.batched(x.conformer.topology.geometry, 3),
+        ):
+            print(f"  {str(atom)} {coords}", file=sys.stderr)
+        print(f"  {x.stats}", file=sys.stderr)
+    print("", file=sys.stderr)
+    n = i + 1
+    assert n == 5
+
+    # res[1] expected to fail
+    assert isinstance(res[1], RunError)
+    print(res[1])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Add Auto3DResult/Auto3DStats dataclasses and save_outputs() for downloading and packaging multiple conformers per input. Bump auto3d_rex module revision and version to 6.8.0.

Closes #3 