### PR TITLE
fix: docs deploy

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -54,7 +54,7 @@ jobs:
             git config user.name "github-actions[bot]"
             git config user.email "github-actions[bot]@users.noreply.github.com"
             git commit -m "Update docs from rush-py commit ${GITHUB_SHA}"
-            git push origin docs-update
+            git push --force origin docs-update
           fi
 
       - name: Create or update PR in qdx-main-landing

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@
 - CHELPG example and tutorial updated to use `exess.energy()` with export keywords and JSON output
 - Rename docs project to "QDX" and set html_title to "QDX Documentation"
 
+### Fixed
+- Add force push to docs deploy workflow to avoid out of sync issues (don't care about maintaining history on bot managed branch)
+
 ## 6.8.0
 
 ### Changed


### PR DESCRIPTION
The clone only fetches main (depth 1). The git switch docs-update fails (branch not in shallow clone), so it falls through to git switch -c docs-update — creating a new branch from main. Then it tries to push that to origin/docs-update, which already exists with different history → rejected.
The fix: force push, since docs-update is a bot-managed branch that should always reflect the latest built docs i.e. don't care about preserving its history