### PR TITLE
Fix: false restoration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 6.10.2
+
+### Fixed
+- Don't print message about run being restored if the run is canceled or failed: this usually means that the module instance couldn't be started at all because the account tier doesn't support running that module instance. The other potential cause is if a module isn't available for a particular target and the user tries to use that combination.
+
 ## 6.10.1
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 - Don't print message about run being restored if the run is canceled or failed: this usually means that the module instance couldn't be started at all because the account tier doesn't support running that module instance. The other potential cause is if a module isn't available for a particular target and the user tries to use that combination.
+- Print and store `trace` field from a run properly when it's either canceled or failed
 
 ## 6.10.1
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "rush-py"
-version = "6.10.1"
+version = "6.10.2"
 description = "Python client for QDX's Rush platform"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/rush/client.py
+++ b/src/rush/client.py
@@ -533,10 +533,7 @@ def _fetch_results(run_id: str):
     return result["run"]
 
 
-def _print_run_trace(run):
-    print(f"Error: {run['result']}", file=sys.stderr)
-
-    trace = run["trace"]
+def _format_failed_run(message: str, trace: str = "") -> str:
     trace = re.sub(
         r"\\u\{([0-9a-fA-F]+)\}",
         lambda m: chr(int(m.group(1), 16)),
@@ -549,19 +546,37 @@ def _print_run_trace(run):
     except (UnicodeDecodeError, UnicodeEncodeError):
         pass
 
+    # This shouldn't be necessary, but we'll leave it in case we have
+    # a module that still manually places stdout and stderr in the trace.
     stdout_match = re.search(r'stdout: Some\("(.*?)"\)', trace, re.DOTALL)
-    if stdout_match:
-        stdout_content = stdout_match.group(1)
-        print("stdout:", file=sys.stderr)
-        for line in stdout_content.split("\n"):
-            print(f"  {line}", file=sys.stderr)
     stderr_match = re.search(r'stderr: Some\("(.*?)"\)', trace, re.DOTALL)
+    trace_without_streams = re.sub(
+        r'stdout: Some\(".*?"\)|stderr: Some\(".*?"\)',
+        "",
+        trace,
+        flags=re.DOTALL,
+    )
+    trace_lines = [line.rstrip() for line in trace_without_streams.splitlines()]
+    trace_lines = [line for line in trace_lines if line.strip()]
+    lines = [message]
+    if trace_lines:
+        lines.append("Trace:")
+        for line in trace_lines:
+            lines.append(f"  {line}")
+
+    if stdout_match:
+        lines.append("stdout:")
+        for line in stdout_match.group(1).split("\n"):
+            lines.append(f"  {line}")
     if stderr_match:
-        stderr_content = stderr_match.group(1)
-        print("stderr:", file=sys.stderr)
-        for line in stderr_content.split("\n"):
-            print(f"  {line}", file=sys.stderr)
-        print(file=sys.stderr)
+        lines.append("stderr:")
+        for line in stderr_match.group(1).split("\n"):
+            lines.append(f"  {line}")
+
+    if trace_lines or stdout_match or stderr_match:
+        lines.append("")
+
+    return "\n".join(lines)
 
 
 type RunStatus = Literal["pending", "running", "done", "error", "cancelled", "draft"]
@@ -573,6 +588,9 @@ class RunError:
 
     message: str
     trace: str = ""
+
+    def __str__(self) -> str:
+        return _format_failed_run(self.message, self.trace)
 
 
 def _build_filters(
@@ -926,18 +944,18 @@ def collect_run(
     status, module_instance_created = _poll_run(run_id, max_wait_time)
     if status not in ["cancelled", "error", "done"]:
         err = f"Run timed out: did not complete within {max_wait_time} seconds"
-        print(err, file=sys.stderr)
-        return RunError(err)
+        run_error = RunError(err)
+        return run_error
 
     run = _fetch_results(run_id)
     if run["status"] == "cancelled":
-        err = f"Cancelled: {run['result']}"
-        print(err, file=sys.stderr)
-        return RunError(err)
+        run_error = RunError(f"Cancelled: {run['result']}", run["trace"] or "")
+        print(run_error, file=sys.stderr)
+        return run_error
     elif run["status"] == "error":
-        err = f"Error: {run['result']}"
-        _print_run_trace(run)
-        return RunError(err)
+        run_error = RunError(f"Error: {run['result']}", run["trace"] or "")
+        print(run_error, file=sys.stderr)
+        return run_error
     elif run["status"] == "done" and not module_instance_created:
         print("Restored already-completed run", file=sys.stderr)
 
@@ -955,20 +973,18 @@ def collect_run(
         if "Ok" in result:
             result = result["Ok"]
         elif "Err" in result:
-            print(f"Error: {result['Err']}", file=sys.stderr)
-            _print_run_trace(run)
-            return RunError(result["Err"])
+            run_error = RunError(f"Error: {result['Err']}", run["trace"] or "")
+            print(run_error, file=sys.stderr)
+            return run_error
 
     # inner error: for logic-level failures (may not exist, but should)
     if is_result_type(result):
         if "Ok" in result:
             result = result["Ok"]
         elif "Err" in result:
-            print(f"Error: {result['Err']}", file=sys.stderr)
-            _print_run_trace(run)
-            return RunError(
-                result["Err"],
-            )
+            run_error = RunError(f"Error: {result['Err']}", run["trace"] or "")
+            print(run_error, file=sys.stderr)
+            return run_error
 
     if len(result) == 1:
         return result[0]

--- a/src/rush/client.py
+++ b/src/rush/client.py
@@ -842,7 +842,7 @@ def fetch_run_info(run_id: str) -> RushRun | None:
     return RushRun(**result["run"] | {"id": run_id})
 
 
-def _poll_run(run_id: str, max_wait_time):
+def _poll_run(run_id: str, max_wait_time) -> tuple[str, bool]:
     query = gql("""
         query GetStatus($id: String!) {
             run(id: $id) {
@@ -873,6 +873,7 @@ def _poll_run(run_id: str, max_wait_time):
     start_time = time.time()
     poll_interval = INITIAL_POLL_INTERVAL
     last_status = None
+    module_instance_created = False
     while time.time() - start_time < max_wait_time:
         time.sleep(poll_interval)
 
@@ -880,6 +881,7 @@ def _poll_run(run_id: str, max_wait_time):
         status = result["run"]["status"]
         module_instances = result["run"]["module_instances"]["nodes"]
         if module_instances:
+            module_instance_created = True
             curr_status = module_instances[0]["status"]
             if curr_status == "running":
                 curr_status = "run"
@@ -906,13 +908,11 @@ def _poll_run(run_id: str, max_wait_time):
             poll_interval = min(poll_interval * BACKOFF_FACTOR, 2)
 
         if status in ["done", "error", "cancelled"]:
-            if not last_status:
-                print("Restored already-completed run", file=sys.stderr)
-            return status
+            return status, module_instance_created
 
         poll_interval = min(poll_interval * BACKOFF_FACTOR, MAX_POLL_INTERVAL)
 
-    return status
+    return status, module_instance_created
 
 
 def collect_run(
@@ -923,7 +923,7 @@ def collect_run(
     actual result of the run, an error string if the run failed, or a string indicating
     that the run timed out.
     """
-    status = _poll_run(run_id, max_wait_time)
+    status, module_instance_created = _poll_run(run_id, max_wait_time)
     if status not in ["cancelled", "error", "done"]:
         err = f"Run timed out: did not complete within {max_wait_time} seconds"
         print(err, file=sys.stderr)
@@ -938,6 +938,8 @@ def collect_run(
         err = f"Error: {run['result']}"
         _print_run_trace(run)
         return RunError(err)
+    elif run["status"] == "done" and not module_instance_created:
+        print("Restored already-completed run", file=sys.stderr)
 
     result = run["result"]
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,7 +9,12 @@ import pytest
 import requests
 
 # Test files that don't submit jobs to the Rush API — always safe to run.
-FAST_TEST_PREFIXES = ("test_convert_", "test_merge", "test_fetch_runs")
+FAST_TEST_PREFIXES = (
+    "test_convert_",
+    "test_merge",
+    "test_fetch_runs",
+    "test_client_collect_run",
+)
 
 # Threshold: if any target has more than this many queued+admitted jobs, skip slow tests.
 QUEUE_BUSY_THRESHOLD = 2

--- a/tests/test_client_collect_run.py
+++ b/tests/test_client_collect_run.py
@@ -50,3 +50,53 @@ def test_collect_run_no_mi_error(
     assert "module `exess_rex` is not available" in result.message
     assert "starting rex evaluation" in stderr
     assert "Restored already-completed run" not in stderr
+
+
+def test_collect_run_prints_non_stream_trace_before_stdio(monkeypatch, capsys):
+    monkeypatch.setattr(
+        "rush.client._poll_run",
+        lambda run_id, max_wait_time: ("error", False),
+    )
+    monkeypatch.setattr(
+        "rush.client._fetch_results",
+        lambda run_id: {
+            "status": "error",
+            "result": "rex evaluation failed",
+            "trace": (
+                'module_state: Some("rex_start_failed")\\n'
+                'reason: Some("module not runnable on this account tier")\\n'
+                'stdout: Some("starting rex evaluation")\\n'
+                'stderr: Some("module `exess_rex` is not available for this account tier")'
+            ),
+        },
+    )
+
+    result = collect_run("run-id")
+
+    stderr = capsys.readouterr().err
+    assert isinstance(result, RunError)
+    assert 'module_state: Some("rex_start_failed")' in stderr
+    assert 'reason: Some("module not runnable on this account tier")' in stderr
+    assert "stdout:" in stderr
+    assert "stderr:" in stderr
+    assert stderr.index("Trace:") < stderr.index("stdout:")
+    assert stderr.index("stdout:") < stderr.index("stderr:")
+
+
+def test_run_error_str_includes_trace_and_stdio_sections():
+    err = RunError(
+        "Error: rex evaluation failed",
+        (
+            'module_state: Some("rex_start_failed")\\n'
+            'stdout: Some("starting rex evaluation")\\n'
+            'stderr: Some("module `exess_rex` is not available for this account tier")'
+        ),
+    )
+
+    formatted = str(err)
+
+    assert "Error: rex evaluation failed" in formatted
+    assert 'module_state: Some("rex_start_failed")' in formatted
+    assert "stdout:" in formatted
+    assert "stderr:" in formatted
+    assert formatted.index("Trace:") < formatted.index("stdout:")

--- a/tests/test_client_collect_run.py
+++ b/tests/test_client_collect_run.py
@@ -1,0 +1,52 @@
+from rush.client import RunError, collect_run
+
+
+def test_collect_run_restored(monkeypatch, capsys):
+    monkeypatch.setattr(
+        "rush.client._poll_run",
+        lambda run_id, max_wait_time: ("done", False),
+    )
+    monkeypatch.setattr(
+        "rush.client._fetch_results",
+        lambda run_id: {
+            "status": "done",
+            "result": [{"path": "output.json"}],
+            "trace": "",
+        },
+    )
+
+    result = collect_run("run-id")
+
+    assert result == {"path": "output.json"}
+    assert "Restored already-completed run" in capsys.readouterr().err
+
+
+def test_collect_run_no_mi_error(
+    monkeypatch, capsys
+):
+    monkeypatch.setattr(
+        "rush.client._poll_run",
+        lambda run_id, max_wait_time: ("error", False),
+    )
+    monkeypatch.setattr(
+        "rush.client._fetch_results",
+        lambda run_id: {
+            "status": "error",
+            "result": (
+                "Module instance creation failed: module `exess_rex` is not "
+                "available for this account tier"
+            ),
+            "trace": (
+                'stdout: Some("starting rex evaluation")\\n'
+                'stderr: Some("module `exess_rex` is not available for this account tier")'
+            ),
+        },
+    )
+
+    result = collect_run("run-id")
+
+    stderr = capsys.readouterr().err
+    assert isinstance(result, RunError)
+    assert "module `exess_rex` is not available" in result.message
+    assert "starting rex evaluation" in stderr
+    assert "Restored already-completed run" not in stderr

--- a/uv.lock
+++ b/uv.lock
@@ -1142,7 +1142,7 @@ wheels = [
 
 [[package]]
 name = "rush-py"
-version = "6.10.1"
+version = "6.10.2"
 source = { editable = "." }
 dependencies = [
     { name = "gql" },


### PR DESCRIPTION
Don't print a message about restoration if the run was canceled or fails because a module instance couldn't be created.

Restoration is still the sole possible reason for a run that calls a module and completes in the `done` state but with no module instances having been created at any point. But, if the run completes in the `error` or `canceled` state but with no module instances, the restoration message is skipped and the correct action is taken in those cases.

This doesn't actually change how rush-py handled the run subsequently, but the confusing and incorrect message is no longer printed in the error or canceled case.

Also, fix a bug where we didn't print and store the full trace info from a failed run properly.