### PR TITLE
docs: rewrite wordy intro sentence for clarity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 6.10.3
+
+### Fixed
+- Rewrite wordy intro sentence in docs landing page for clarity
+
 ## 6.10.2
 
 ### Fixed

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,11 +1,12 @@
 QDX Documentation
 ==================
 
-Welcome to QDX's documentation hub. Here you'll find docs for three key
-components: the **Rush Python SDK** for programmatic access to the
-`Rush platform <https://qdx.co/rush>`__, **EXESS** — our GPU-accelerated
-quantum chemistry engine, and **NN-xTB** — a neural network tight-binding
-method for fast semi-empirical calculations.
+Welcome to QDX's documentation hub. The `Rush platform <https://qdx.co/rush>`__
+is how we make our quantum chemistry technology and drug-discovery applications
+available. These docs cover three key components: the **Rush Python SDK** for
+programmatic access to Rush, **EXESS** — our GPU-accelerated quantum chemistry
+engine, and **NN-xTB** — a neural network tight-binding method for fast
+semi-empirical calculations.
 
 If you prefer a visual interface over scripting, you can use EXESS directly
 `here <https://exess.qdx.co/exess-flow>`__ and the rest of Rush

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,13 +1,11 @@
 QDX Documentation
 ==================
 
-Welcome to QDX's documentation hub. These docs cover the **Rush Python
-SDK** for programmatic access to the `Rush platform <https://qdx.co/rush>`__,
-which is how we make our quantum chemistry technology available along with
-vertical applications to drug discovery developed by our R&D team, the
-**EXESS** quantum chemistry engine that powers many of its calculations,
-and the **NN-xTB** neural network tight-binding method for fast
-semi-empirical calculations.
+Welcome to QDX's documentation hub. Here you'll find docs for three key
+components: the **Rush Python SDK** for programmatic access to the
+`Rush platform <https://qdx.co/rush>`__, **EXESS** — our GPU-accelerated
+quantum chemistry engine, and **NN-xTB** — a neural network tight-binding
+method for fast semi-empirical calculations.
 
 If you prefer a visual interface over scripting, you can use EXESS directly
 `here <https://exess.qdx.co/exess-flow>`__ and the rest of Rush

--- a/tests/test_client_collect_run.py
+++ b/tests/test_client_collect_run.py
@@ -21,9 +21,7 @@ def test_collect_run_restored(monkeypatch, capsys):
     assert "Restored already-completed run" in capsys.readouterr().err
 
 
-def test_collect_run_no_mi_error(
-    monkeypatch, capsys
-):
+def test_collect_run_no_mi_error(monkeypatch, capsys):
     monkeypatch.setattr(
         "rush.client._poll_run",
         lambda run_id, max_wait_time: ("error", False),


### PR DESCRIPTION
Split the run-on intro sentence in docs/index.rst into a cleaner structure that introduces each component (Rush SDK, EXESS, NN-xTB) without the convoluted nesting.